### PR TITLE
makes list-detail template work in firefox Aurora/Nightly

### DIFF
--- a/www/js/lib/layouts/css-animations.js
+++ b/www/js/lib/layouts/css-animations.js
@@ -1,4 +1,3 @@
-
 (function() {
 
     // Utility
@@ -81,7 +80,11 @@
 		}
 		cssRule += "}";
 
-		this.original.insertRule(cssRule);
+		if('appendRule' in this.original) {
+			this.original.appendRule(cssRule);
+		} else {
+			this.original.insertRule(cssRule);
+		} 
 		this.initKeyframes();
 	};
 


### PR DESCRIPTION
FIxes issue 4 of css-animations ('insertRule doesn't exist in W3C CSSKeyframesRule interface'). See https://github.com/jlongster/css-animations.js/issues/4

The pull request applies the orignal fix of jlongster on the mortar-list-detail repo: 
https://github.com/jlongster/css-animations.js/commit/bedeff09f1e716f8fab5879d385397b0e511ad77
